### PR TITLE
Better support for piped input

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -10,6 +10,8 @@ namespace odbc_cli
     {
         static void Main(string[] args)
         {
+            var exitOnEmptyStdin = args.LastOrDefault() == "-";
+
             if (!File.Exists(".config.json"))
             {
                 throw new InvalidOperationException(".config.json could not be found.");
@@ -46,6 +48,18 @@ namespace odbc_cli
                     Console.Write("> ");
                     var input = Console.ReadLine();
                     Console.ForegroundColor = ConsoleColor.Blue;
+                    
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        if (exitOnEmptyStdin)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            continue;
+                        }
+                    }
 
                     var command = new OdbcCommand(input);
                     command.Connection = connection;

--- a/Program.cs
+++ b/Program.cs
@@ -60,6 +60,12 @@ namespace odbc_cli
                             continue;
                         }
                     }
+                    
+                    if (exitOnEmptyStdin)
+                    {
+                        // an extra \n makes things nicer for piped input
+                        Console.WriteLine();
+                    }
 
                     var command = new OdbcCommand(input);
                     command.Connection = connection;

--- a/Program.cs
+++ b/Program.cs
@@ -51,14 +51,7 @@ namespace odbc_cli
                     
                     if (string.IsNullOrEmpty(input))
                     {
-                        if (exitOnEmptyStdin)
-                        {
-                            break;
-                        }
-                        else
-                        {
-                            continue;
-                        }
+                        break;
                     }
                     
                     if (exitOnEmptyStdin)

--- a/README.md
+++ b/README.md
@@ -8,14 +8,48 @@ I needed a program that let me write quick test queries, executed said queries u
 
 ## How to use
 
-+ Get [The latest release](https://github.com/bengreenier/odbc-cli/releases/latest)
-+ Modify (or create) `.config.json` next to the binary, with the following JSON content, populated for your use case:
+- Get [The latest release](https://github.com/bengreenier/odbc-cli/releases/latest)
+- Modify (or create) `.config.json` next to the binary, with the following JSON content, populated for your use case:
+
 ```
 {
  "connectionString": "Driver={Custom ODBC};Host=mysite.com;Port=1337;Ssl=1;AuthMech=0;"
 }
 ```
-+ Run `odbc-cli.exe`
+
+- Run `odbc-cli.exe`
+
+## Arguments
+
+The following sections describe the possible command line arguments.
+
+### -
+
+> Yes you read that correctly, simply `-` as a final argument.
+
+This argument is used to indicate that empty stdin input should exit
+the application. This affects both the REPL and piped input, but is most
+useful in the piped scenario. For instance:
+
+```
+cat some_newline_delim_queries.txt | odbc-cli.exe -
+```
+
+Will cause the program to exit after all querys have run.
+
+## Configuration
+
+The following sections describe the json configuration values.
+
+### connectionString
+
+An ODBC connection string that we'll use to connect to the serivce.
+
+### disableOutput
+
+Disables printing results to stdout.
+
+Note timing information is still printed for each query.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A small ODBC driver test program
 
 ![CD Badge](https://github.com/bengreenier/odbc-cli/workflows/Master%20CD/badge.svg)
+![CI Badge](https://github.com/bengreenier/odbc-cli/workflows/Master%20CI/badge.svg)
 
 I needed a program that let me write quick test queries, executed said queries using an installed ODBC driver, and showed the results. This is that program.
 


### PR DESCRIPTION
Addresses #3 

The underlying support for reading queries from piped input (incl files) is/was already in place, but causes some error cases.

This PR adds support for `-` as a final argument, which will explicitly handle these error cases correctly. It's firmly a "quick fix" but does the job quite well.

Further improved readme.

